### PR TITLE
Improve readme - make Image type more clear

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,9 +73,9 @@ Samples.VerifyImageFile.verified.jpg
 <img src="/src/Tests/Samples.VerifyImageFile.verified.jpg" width="200px">
 
 
-### Verify an Image
+### Verify an SixLabors.ImageSharp.Image
 
-An instance if an `Image` can be verified using the following:
+An instance if an `SixLabors.ImageSharp.Image` can be verified using the following:
 
 <!-- snippet: VerifyImage -->
 <a id='snippet-verifyimage'></a>


### PR DESCRIPTION
SixLabors.ImageSharp.Image <> System.Drawing.Image 

I was confused it was only printing "System.Drawing.Image" (or "System.Drawing.Bitmap")